### PR TITLE
31 add eiken records table

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -47,13 +47,7 @@
 //ぱんくず
 @import './breadcrumb/breadcrumb';
 
-
-
-
-
-
-
-
-
-
-
+//英検記録ページ
+@import "./eiken_records/eiken_records_index";
+@import "./eiken_records/eiken_records_show";
+@import "./eiken_records/eiken_records_new";

--- a/app/assets/stylesheets/audio/audio_script.scss
+++ b/app/assets/stylesheets/audio/audio_script.scss
@@ -35,10 +35,10 @@
   padding: 12px 16px;
   border-radius: 12px;
   background-color: #e1e1e1;
-  width: 100%;
+  // width: 100%;
   font-size: 14px;
   opacity: 0;
-  transform: translateX(20px);
+  transform: translateX(0px);
   will-change: transform, opacity;
   transition:
     transform 0.4s ease,

--- a/app/assets/stylesheets/eiken_records/eiken_records_index.scss
+++ b/app/assets/stylesheets/eiken_records/eiken_records_index.scss
@@ -1,0 +1,201 @@
+/* ===== 変数 ===== */
+$bg: #F7F9FC;
+$white: #FFFFFF;
+$border: #E4EAF2;
+$text: #2C3E50;
+$text-muted: #8A99AD;
+$primary: #2C3E50;
+$accent: #3B82F6;
+$danger: #EF4444;
+$radius: 12px;
+
+/* ===== コンテナ ===== */
+.eiken-records-container {
+  width: 100%;
+  max-width: 990px;
+  margin: 0 auto;
+  padding: 0 24px 20px;
+  box-sizing: border-box;
+}
+
+/* ===== ヘッダー ===== */
+.eiken-records-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  h2 {
+    font-size: 30px;
+    font-weight: 700;
+    text-align: center;
+    margin: 40px 0 50px;
+    letter-spacing: 0.05em;
+    color: #222;
+  }
+
+  .new-record-btn {
+    background: $accent;
+    color: $white;
+    border-radius: 8px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: bold;
+    text-decoration: none;
+    transition: background 0.2s;
+
+    &:hover {
+      background: darken($accent, 10%);
+    }
+  }
+}
+
+/* ===== テーブル ===== */
+.eiken-records-table-wrapper {
+  background: $white;
+  border-radius: $radius;
+  border: 1px solid $border;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.eiken-records-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  thead {
+    background: $primary;
+
+    th {
+      color: $white;
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      text-align: center;
+      white-space: nowrap;
+    }
+  }
+
+  tbody {
+    tr {
+      border-bottom: 1px solid $border;
+      transition: background 0.15s;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &:hover {
+        background: #F0F5FF;
+      }
+    }
+
+    td {
+      padding: 14px 16px;
+      font-size: 14px;
+      color: $text;
+      text-align: center;
+    }
+  }
+
+  /* 合計スコア強調 */
+  .total-score {
+    font-weight: bold;
+    color: $accent;
+    font-size: 15px;
+  }
+
+  /* スコアなしの場合 */
+  .no-score {
+    color: $text-muted;
+  }
+
+  /* 削除ボタン */
+  .delete-btn {
+    background: $danger;
+    color: $white;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    text-decoration: none;
+    transition: background 0.2s;
+
+    &:hover {
+      background: darken($danger, 10%);
+    }
+  }
+}
+
+.edit-btn {
+  background: #3B82F6;
+  color: white;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  text-decoration: none;
+  margin-right: 6px;
+  transition: background 0.2s;
+
+  &:hover {
+    background: darken(#3B82F6, 10%);
+  }
+}
+
+.show-btn {
+  background: #2cd153;
+  color: white;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  text-decoration: none;
+  margin-right: 6px;
+  transition: background 0.2s;
+
+  &:hover {
+    background: darken(#2cd153, 10%);
+  }
+}
+
+/* ===== 英検級バッジ ===== */
+.level-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+/* ===== 空の状態 ===== */
+.eiken-records-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: $text-muted;
+
+  p {
+    font-size: 15px;
+    margin-bottom: 16px;
+  }
+}
+
+.badge-pass {
+  background: #10B981;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.badge-fail {
+  background: #EF4444;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.badge-unknown {
+  color: #8A99AD;
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/eiken_records/eiken_records_new.scss
+++ b/app/assets/stylesheets/eiken_records/eiken_records_new.scss
@@ -1,0 +1,172 @@
+/* app/assets/stylesheets/eiken_records/eiken_new.scss */
+
+$bg: #F7F9FC;
+$white: #FFFFFF;
+$border: #E4EAF2;
+$text: #2C3E50;
+$text-muted: #8A99AD;
+$primary: #2C3E50;
+$accent: #3B82F6;
+$radius: 12px;
+
+.eiken-new-container {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 32px 16px 100px;
+  min-height: 100vh;
+}
+
+.eiken-new-card {
+  background: $white;
+  border-radius: $radius;
+  border: 1px solid $border;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+/* ===== ヘッダー ===== */
+.eiken-new-header {
+  background: $primary;
+  padding: 24px;
+  color: $white;
+
+  h2 {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
+
+  p {
+    font-size: 13px;
+    opacity: 0.7;
+  }
+}
+
+/* ===== フォーム ===== */
+.eiken-new-form {
+  padding: 24px;
+}
+
+.form-section {
+  margin-bottom: 28px;
+
+  .section-title {
+    font-size: 14px;
+    font-weight: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid $border;
+  }
+}
+
+.form-group {
+  margin-bottom: 16px;
+
+  .form-label {
+    display: block;
+    font-size: 13px;
+    font-weight: bold;
+    color: $text;
+    margin-bottom: 6px;
+  }
+
+  .form-control,
+  .form-select {
+    width: 100%;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 14px;
+    color: $text;
+    background: $white;
+    transition: border 0.2s, box-shadow 0.2s;
+
+    &:focus {
+      border-color: $accent;
+      outline: none;
+      box-shadow: 0 0 0 3px rgba($accent, 0.15);
+    }
+
+    &::placeholder {
+      color: $text-muted;
+    }
+  }
+
+  .memo-field {
+    height: 100px;
+    resize: vertical;
+  }
+}
+
+/* ===== スコアグリッド ===== */
+.score-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.score-label-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.score-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: bold;
+  color: $white;
+
+  &.speaking  { background: #3B82F6; }
+  &.reading   { background: #10B981; }
+  &.listening { background: #F59E0B; }
+  &.writing   { background: #8B5CF6; }
+}
+
+/* ===== ボタン ===== */
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+
+  .cancel-btn {
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: bold;
+    color: $text-muted;
+    border: 1px solid $border;
+    text-decoration: none;
+    transition: background 0.2s;
+
+    &:hover {
+      background: $bg;
+    }
+  }
+
+  .submit-btn {
+    padding: 10px 24px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: bold;
+    background: $accent;
+    color: $white;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s;
+
+    &:hover {
+      background: darken($accent, 10%);
+    }
+  }
+}

--- a/app/assets/stylesheets/eiken_records/eiken_records_show.scss
+++ b/app/assets/stylesheets/eiken_records/eiken_records_show.scss
@@ -1,0 +1,166 @@
+$bg: #F7F9FC;
+$white: #FFFFFF;
+$border: #E4EAF2;
+$text: #2C3E50;
+$text-muted: #8A99AD;
+$radius: 12px;
+
+.eiken-show-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 32px 16px 100px;
+  min-height: 100vh;
+}
+
+.eiken-show-card {
+  background: $white;
+  border-radius: $radius;
+  border: 1px solid $border;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+/* ===== ヘッダー ===== */
+.eiken-show-header {
+  padding: 24px 24px 0 24px;
+  text-align: center;
+
+  .show-level-badge {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.25);
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
+
+  .show-exam-date {
+    font-size: 14px;
+    margin-top: 8px;
+  }
+}
+
+/* ===== ボディ ===== */
+.eiken-show-body {
+  padding: 24px;
+}
+
+.show-section {
+  margin-bottom: 28px;
+
+  .show-section-title {
+    font-size: 13px;
+    font-weight: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid $border;
+  }
+}
+
+/* ===== スコアカード ===== */
+.score-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.score-card {
+  border-radius: 10px;
+  padding: 16px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &.speaking  { background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.2); }
+  &.reading   { background: rgba(16, 185, 129, 0.1); border: 1px solid rgba(16, 185, 129, 0.2); }
+  &.listening { background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.2); }
+  &.writing   { background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.2); }
+
+  .score-card-label {
+    font-size: 12px;
+    font-weight: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+  }
+
+  .score-card-value {
+    font-size: 28px;
+    font-weight: bold;
+    color: $text;
+  }
+}
+
+/* ===== 合計スコア ===== */
+.total-score-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #F0F5FF;
+  border-radius: 10px;
+  padding: 14px 20px;
+  border: 1px solid #DBEAFE;
+
+  .total-score-label {
+    font-size: 14px;
+    font-weight: bold;
+    color: $text;
+  }
+
+  .total-score-value {
+    font-size: 24px;
+    font-weight: bold;
+    color: #3B82F6;
+  }
+}
+
+/* ===== メモ ===== */
+.show-memo {
+  font-size: 14px;
+  color: $text;
+  line-height: 1.7;
+  background: $bg;
+  border-radius: 8px;
+  padding: 14px;
+  border: 1px solid $border;
+}
+
+/* ===== アクション ===== */
+.show-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 8px;
+
+  a {
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: bold;
+    text-decoration: none;
+    transition: opacity 0.2s;
+
+    &:hover { opacity: 0.85; }
+  }
+
+  .edit-btn {
+    background:#3B82F6;
+    color: white;
+  }
+
+  .delete-btn {
+    background: #EF4444;
+    color: white;
+  }
+
+  .back-btn {
+    background: $bg;
+    color: $text;
+    border: 1px solid $border;
+  }
+}

--- a/app/controllers/eiken_records_controller.rb
+++ b/app/controllers/eiken_records_controller.rb
@@ -1,0 +1,49 @@
+class EikenRecordsController < ApplicationController
+  def index
+    @eiken_records = current_user.eiken_records.order(exam_date: :desc)
+  end
+
+  def show
+    @eiken_record = current_user.eiken_records.find(params[:id])
+  end
+
+  def new
+    @eiken_record = EikenRecord.new
+  end
+
+  def create
+    @eiken_record = current_user.eiken_records.build(eiken_records_params)
+    if @eiken_record.save
+      redirect_to eiken_records_path, notice: "英検スコアを新しく記録しました"
+    else
+      render :new, status: :unprocessable_entity
+      flash.now[:danger] = "新しく記録できませんでした。"
+    end
+  end
+
+  def edit
+    @eiken_record = current_user.eiken_records.find(params[:id])
+  end
+
+  def update
+    @eiken_record = current_user.eiken_records.find(params[:id])
+    if @eiken_record.update(eiken_records_params)
+      redirect_to eiken_records_path, notice: "英検スコアを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+      flash.now[:danger] = "更新できませんでした。"
+    end
+  end
+
+  def destroy
+    @eiken_record = current_user.eiken_records.find(params[:id])
+    @eiken_record.destroy
+    redirect_to eiken_records_path, notice: "削除しました"
+  end
+
+  private
+
+  def eiken_records_params
+    params.require(:eiken_record).permit(:level, :speaking_score, :reading_score, :listening_score, :writing_score, :exam_date, :passed, :memo)
+  end
+end

--- a/app/helpers/eiken_records_helper.rb
+++ b/app/helpers/eiken_records_helper.rb
@@ -1,0 +1,2 @@
+module EikenRecordsHelper
+end

--- a/app/models/eiken_record.rb
+++ b/app/models/eiken_record.rb
@@ -3,7 +3,7 @@ class EikenRecord < ApplicationRecord
 
   validates :exam_date, presence: :true
   validates :level, presence: :true
-  validates :passed, presence: :true
+  validates :passed, inclusion: { in: [true, false] }
 
   def total_score
     [ speaking_score, reading_score, listening_score, writing_score ].compact.sum

--- a/app/models/eiken_record.rb
+++ b/app/models/eiken_record.rb
@@ -1,0 +1,11 @@
+class EikenRecord < ApplicationRecord
+  belongs_to :user
+
+  validates :exam_date, presence: :true
+  validates :level, presence: :true
+  validates :passed, presence: :true
+
+  def total_score
+    [ speaking_score, reading_score, listening_score, writing_score ].compact.sum
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   has_many :saved_textbooks, through: :booklists, source: :textbook
   has_many :learning_records, dependent: :destroy
   has_many :learning_records_audio, through: :learning_records, source: :audio
+  has_many :eiken_records, dependent: :destroy
 
   def email_required?
     false
@@ -76,4 +77,6 @@ class User < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     []
   end
+
+  EIKEN_LEVELS = [ "英検5級", "英検4級", "英検3級", "英検準2級", "英検準2級プラス", "英検2級", "英検準1級", "英検1級" ]
 end

--- a/app/views/eiken_records/edit.html.erb
+++ b/app/views/eiken_records/edit.html.erb
@@ -1,0 +1,84 @@
+<div class="eiken-new-container">
+  <div class="eiken-new-card">
+
+    <div class="eiken-new-header">
+      <h2>英検スコアの編集</h2>
+      <p>英検の受験結果を記録しましょう</p>
+    </div>
+
+    <%= form_with model: @eiken_record, data: { turbo: false }, class: "eiken-new-form" do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+      <div class="form-section">
+        <h3 class="section-title">基本情報</h3>
+        <div class="form-group">
+          <%= f.label :level, "受験級", class: "form-label" %>
+          <%= f.select :level,
+              User::EIKEN_LEVELS,
+              { include_blank: "選択してください" },
+              class: "form-select" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :exam_date, "受験日", class: "form-label" %>
+          <%= f.date_field :exam_date, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h3 class="section-title">スコア **記録するスコアがなければ未記入のままにしてください。</h3>
+
+        <div class="score-grid">
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon reading">R</span>
+              <%= f.label :reading_score, "Reading", class: "form-label" %>
+            </div>
+            <%= f.number_field :reading_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon listening">L</span>
+              <%= f.label :listening_score, "Listening", class: "form-label" %>
+            </div>
+            <%= f.number_field :listening_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon writing">W</span>
+              <%= f.label :writing_score, "Writing", class: "form-label" %>
+            </div>
+            <%= f.number_field :writing_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon speaking">S</span>
+              <%= f.label :speaking_score, "Speaking", class: "form-label" %>
+            </div>
+            <%= f.number_field :speaking_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h3 class="section-title">メモ</h3>
+        <div class="form-group">
+          <%= f.text_area :memo,
+              class: "form-control memo-field",
+              placeholder: "次回に向けての目標や感想など" %>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <%= link_to "キャンセル", eiken_records_path, class: "cancel-btn" %>
+        <%= f.submit "更新する", class: "submit-btn" %>
+      </div>
+
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/navigation_bar" %>

--- a/app/views/eiken_records/edit.html.erb
+++ b/app/views/eiken_records/edit.html.erb
@@ -22,10 +22,18 @@
           <%= f.label :exam_date, "受験日", class: "form-label" %>
           <%= f.date_field :exam_date, class: "form-control" %>
         </div>
+
+        <div class="form-group">
+          <%= f.label :passed, "結果 *必須", class: "form-label" %>
+          <%= f.select :passed,
+              [["合格", true], ["不合格", false], ["未受験・未確認", nil]],
+              { include_blank: false },
+              class: "form-select" %>
+        </div>
       </div>
 
       <div class="form-section">
-        <h3 class="section-title">スコア **記録するスコアがなければ未記入のままにしてください。</h3>
+        <h3 class="section-title">スコア *記録するスコアがなければ未記入のままにしてください。</h3>
 
         <div class="score-grid">
 

--- a/app/views/eiken_records/index.html.erb
+++ b/app/views/eiken_records/index.html.erb
@@ -1,0 +1,75 @@
+<%# app/views/eiken_records/index.html.erb %>
+<div class="eiken-records-container">
+  <div class="eiken-records-header">
+    <h2><%= current_user.name %>さんの英検スコア</h2>
+    <%= link_to "+ 英検スコアを追加する", new_eiken_record_path, class: "new-record-btn" %>
+  </div>
+
+  <% if @eiken_records.empty? %>
+    <div class="eiken-records-empty">
+      <p>まだ受験記録がありません</p>
+      <%= link_to "+ 最初の英検スコアを追加する", new_eiken_record_path, class: "new-record-btn" %>
+    </div>
+  <% else %>
+    <div class="eiken-records-table-wrapper">
+      <table class="eiken-records-table">
+        <thead>
+          <tr>
+            <th>受験日</th>
+            <th>英検級</th>
+            <th>Reading</th>
+            <th>Listening</th>
+            <th>Writing</th>
+            <th>Speaking</th>
+            <th>合計</th>
+            <th>結果</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @eiken_records.each do |record| %>
+              <tr>
+                <td><%= record.exam_date&.strftime("%Y/%m/%d") %></td>
+                <td>
+                  <span class="level-badge">
+                    <%= record.level %>
+                  </span>
+                </td>
+                <td class="<%= record.reading_score ? '' : 'no-score' %>">
+                  <%= record.reading_score || "-" %>
+                </td>
+                <td class="<%= record.listening_score ? '' : 'no-score' %>">
+                  <%= record.listening_score || "-" %>
+                </td>
+                <td class="<%= record.writing_score ? '' : 'no-score' %>">
+                  <%= record.writing_score || "-" %>
+                </td>
+                <td class="<%= record.speaking_score ? '' : 'no-score' %>">
+                  <%= record.speaking_score || "-" %>
+                </td>
+                <td class="total-score"><%= record.total_score %></td>
+                <td>
+                  <% if record.passed.nil? %>
+                    <span class="badge-unknown">-</span>
+                  <% elsif record.passed %>
+                    <span class="badge-pass">合格</span>
+                  <% else %>
+                    <span class="badge-fail">不合格</span>
+                  <% end %>
+                </td>
+                <td>
+                  <%= link_to "詳細", eiken_record_path(record), class: "show-btn" %>
+                  <%= link_to "編集", edit_eiken_record_path(record), class: "edit-btn" %>
+                  <%= link_to "削除", eiken_record_path(record),
+                      class: "delete-btn",
+                      data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+                </td>
+              </tr>
+            <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>
+
+<%= render "shared/navigation_bar" %>

--- a/app/views/eiken_records/new.html.erb
+++ b/app/views/eiken_records/new.html.erb
@@ -1,0 +1,92 @@
+<div class="eiken-new-container">
+  <div class="eiken-new-card">
+
+    <div class="eiken-new-header">
+      <h2>英検スコアを追加</h2>
+      <p>英検の受験結果を記録しましょう</p>
+    </div>
+
+    <%= form_with model: @eiken_record, data: { turbo: false }, class: "eiken-new-form" do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+      <div class="form-section">
+        <h3 class="section-title">基本情報</h3>
+        <div class="form-group">
+          <%= f.label :level, "受験級 *必須", class: "form-label" %>
+          <%= f.select :level,
+              User::EIKEN_LEVELS,
+              { include_blank: "選択してください" },
+              class: "form-select" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :exam_date, "受験日 *必須", class: "form-label" %>
+          <%= f.date_field :exam_date, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :passed, "結果 *必須", class: "form-label" %>
+          <%= f.select :passed,
+              [["合格", true], ["不合格", false], ["未受験・未確認", nil]],
+              { include_blank: false },
+              class: "form-select" %>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h3 class="section-title">スコア *記録するスコアがなければ未記入のままにしてください。</h3>
+
+        <div class="score-grid">
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon reading">R</span>
+              <%= f.label :reading_score, "Reading", class: "form-label" %>
+            </div>
+            <%= f.number_field :reading_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon listening">L</span>
+              <%= f.label :listening_score, "Listening", class: "form-label" %>
+            </div>
+            <%= f.number_field :listening_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon writing">W</span>
+              <%= f.label :writing_score, "Writing", class: "form-label" %>
+            </div>
+            <%= f.number_field :writing_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+
+          <div class="form-group">
+            <div class="score-label-wrapper">
+              <span class="score-icon speaking">S</span>
+              <%= f.label :speaking_score, "Speaking", class: "form-label" %>
+            </div>
+            <%= f.number_field :speaking_score, min: 0, class: "form-control", placeholder: "例: 600" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h3 class="section-title">メモ</h3>
+        <div class="form-group">
+          <%= f.text_area :memo,
+              class: "form-control memo-field",
+              placeholder: "次回に向けての目標や感想など" %>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <%= link_to "キャンセル", eiken_records_path, class: "cancel-btn" %>
+        <%= f.submit "保存する", class: "submit-btn" %>
+      </div>
+
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/navigation_bar" %>

--- a/app/views/eiken_records/show.html.erb
+++ b/app/views/eiken_records/show.html.erb
@@ -1,0 +1,61 @@
+<%# app/views/eiken_records/show.html.erb %>
+<div class="eiken-show-container">
+  <div class="eiken-show-card">
+
+    <div class="eiken-show-header">
+      <span class="show-level-badge"><%= @eiken_record.level %></span>
+      <p class="show-exam-date"><%= @eiken_record.exam_date&.strftime("%Y年%m月%d日") %></p>
+    </div>
+
+    <div class="eiken-show-body">
+
+      <%# スコアセクション %>
+      <div class="show-section">
+        <h3 class="show-section-title">スコア</h3>
+        <div class="score-cards">
+          <div class="score-card reading">
+            <span class="score-card-label">Reading</span>
+            <span class="score-card-value"><%= @eiken_record.reading_score || "-" %></span>
+          </div>
+          <div class="score-card listening">
+            <span class="score-card-label">Listening</span>
+            <span class="score-card-value"><%= @eiken_record.listening_score || "-" %></span>
+          </div>
+          <div class="score-card writing">
+            <span class="score-card-label">Writing</span>
+            <span class="score-card-value"><%= @eiken_record.writing_score || "-" %></span>
+          </div>
+          <div class="score-card speaking">
+            <span class="score-card-label">Speaking</span>
+            <span class="score-card-value"><%= @eiken_record.speaking_score || "-" %></span>
+          </div>
+        </div>
+
+        <div class="total-score-row">
+          <span class="total-score-label">合計スコア</span>
+          <span class="total-score-value"><%= @eiken_record.total_score %></span>
+        </div>
+      </div>
+
+      <%# メモセクション %>
+      <% if @eiken_record.memo.present? %>
+        <div class="show-section">
+          <h3 class="show-section-title">メモ</h3>
+          <p class="show-memo"><%= @eiken_record.memo %></p>
+        </div>
+      <% end %>
+
+      <%# アクション %>
+      <div class="show-actions">
+        <%= link_to "編集", edit_eiken_record_path(@eiken_record), class: "edit-btn" %>
+        <%= link_to "削除", eiken_record_path(@eiken_record),
+            class: "delete-btn",
+            data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+        <%= link_to "一覧に戻る", eiken_records_path, class: "back-btn" %>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<%= render "shared/navigation_bar" %>

--- a/app/views/shared/_navigation_bar.html.erb
+++ b/app/views/shared/_navigation_bar.html.erb
@@ -19,5 +19,11 @@
       <span>マイテキスト</span>
     <% end %>
 
+    <%= link_to eiken_records_path,
+        class: "tab-item #{current_page?(eiken_records_path) ? 'active' : ''}" do %>
+      <i class="fa-solid fa-flag-checkered"></i>
+      <span>目標設定</span>
+    <% end %>
+
   </div>
 </section>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -4,7 +4,7 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
-  config.site_title = "Myapp"
+  config.site_title = "LISTENER2.0"
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions"
@@ -18,4 +19,5 @@ Rails.application.routes.draw do
 
   resources :favorites, only: [ :index ]
   resources :booklists, only: [ :index, :create, :destroy ]
+  resources :eiken_records, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
 end

--- a/db/migrate/20260609060214_create_eiken_records.rb
+++ b/db/migrate/20260609060214_create_eiken_records.rb
@@ -1,0 +1,16 @@
+class CreateEikenRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :eiken_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :level
+      t.integer :speaking_score
+      t.integer :reading_score
+      t.integer :listening_score
+      t.integer :writing_score
+      t.date :exam_date
+      t.text :memo
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260609083802_add_passed_to_eiken_records.rb
+++ b/db/migrate/20260609083802_add_passed_to_eiken_records.rb
@@ -1,0 +1,5 @@
+class AddPassedToEikenRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :eiken_records, :passed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_08_075154) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_09_083802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_08_075154) do
     t.index ["textbook_id"], name: "index_booklists_on_textbook_id"
     t.index ["user_id", "textbook_id"], name: "index_booklists_on_user_id_and_textbook_id", unique: true
     t.index ["user_id"], name: "index_booklists_on_user_id"
+  end
+
+  create_table "eiken_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "level"
+    t.integer "speaking_score"
+    t.integer "reading_score"
+    t.integer "listening_score"
+    t.integer "writing_score"
+    t.date "exam_date"
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "passed"
+    t.index ["user_id"], name: "index_eiken_records_on_user_id"
   end
 
   create_table "favorites", force: :cascade do |t|
@@ -124,6 +139,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_08_075154) do
   add_foreign_key "audios", "lessons"
   add_foreign_key "booklists", "textbooks"
   add_foreign_key "booklists", "users"
+  add_foreign_key "eiken_records", "users"
   add_foreign_key "favorites", "audios"
   add_foreign_key "favorites", "users"
   add_foreign_key "learning_records", "audios"

--- a/test/controllers/eiken_records_controller_test.rb
+++ b/test/controllers/eiken_records_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EikenRecordsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/eiken_records.yml
+++ b/test/fixtures/eiken_records.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  level: MyString
+  speaking_score: 1
+  reading_score: 1
+  listening_score: 1
+  writing_score: 1
+  exam_date: 2026-06-09
+  memo: MyText
+
+two:
+  user: two
+  level: MyString
+  speaking_score: 1
+  reading_score: 1
+  listening_score: 1
+  writing_score: 1
+  exam_date: 2026-06-09
+  memo: MyText

--- a/test/models/eiken_record_test.rb
+++ b/test/models/eiken_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EikenRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更点
-  eiken_recordsテーブルを追加
### カラム
- level（受験した英検級）
- speaking_score
- reading_score
- listening_score
- writing_score
- passed（合否）
- exam_date（受験日）

## 追加した背景
- 大学受験で英検のスコアが重要視されるようになったため。
- スコアや合否を記録させることで、意識が高まる。

## 変更予定
- 自分の目標点の設定
- 過去のスコアのグラフ化
